### PR TITLE
Main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,6 @@
-# gitflow-test
-In this repository you will find information on Git-Flow
+# Git Flow Process/Procedure
 
-https://nvie.com/posts/a-successful-git-branching-model/
-https://github.com/nvie/gitflow
-https://jeffkreeftmeijer.com/git-flow/
+Process/Procedure using the git-flow tool in git-flow.md
 
-This was typed on the development branch, branch protections should prevent commits directly to the development branch
-
-First pass at proections did not work, so I had to add additional branch protections to prevent direct commits to main and development. They are now working and this comment is from feature branch add-comment-about-proections which was created with this command:
-
-git flow feature start add-comment-about-protections
-
-Since Git-Flow takes a local first approach the branch is created locally first. When you want to push code up to GitHub remote you will need to run a command like this to create the branch on the remote/origin and push the code up
-
-git push --set-upstream origin feature/add-comment-about-protections
-
-To finish the feature we are going to make one last commit to this branch, then create a Pull Request to merge changes from add-comment-about-protections to the development branch. Once the PR requirements/protections have been satisfied we will click Squash & Merge in the GitHub UI.
-
-The checkout the development branch locally, pull the most recent changes and then run:
-
-git flow feature finish add-comment-about-protections
-
-This will close the feature branch and get us ready to start a new feature branch.
-
-
-This was typed on the main branch, branch protections should prevent commits directly to the main branch
+Process/Procedure using adapted standard git flow in git-process.md
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,28 @@
 # gitflow-test
 In this repository you will find information on Git-Flow
 
+https://nvie.com/posts/a-successful-git-branching-model/
+https://github.com/nvie/gitflow
+https://jeffkreeftmeijer.com/git-flow/
+
+This was typed on the development branch, branch protections should prevent commits directly to the development branch
+
+First pass at proections did not work, so I had to add additional branch protections to prevent direct commits to main and development. They are now working and this comment is from feature branch add-comment-about-proections which was created with this command:
+
+git flow feature start add-comment-about-protections
+
+Since Git-Flow takes a local first approach the branch is created locally first. When you want to push code up to GitHub remote you will need to run a command like this to create the branch on the remote/origin and push the code up
+
+git push --set-upstream origin feature/add-comment-about-protections
+
+To finish the feature we are going to make one last commit to this branch, then create a Pull Request to merge changes from add-comment-about-protections to the development branch. Once the PR requirements/protections have been satisfied we will click Squash & Merge in the GitHub UI.
+
+The checkout the development branch locally, pull the most recent changes and then run:
+
+git flow feature finish add-comment-about-protections
+
+This will close the feature branch and get us ready to start a new feature branch.
+
+
 This was typed on the main branch, branch protections should prevent commits directly to the main branch
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # gitflow-test
 In this repository you will find information on Git-Flow
+
+This was typed on the main branch, branch protections should prevent commits directly to the main branch

--- a/git-flow.md
+++ b/git-flow.md
@@ -1,0 +1,43 @@
+# gitflow-test
+In this repository you will find information on Git-Flow
+
+https://nvie.com/posts/a-successful-git-branching-model/
+https://github.com/nvie/gitflow
+https://jeffkreeftmeijer.com/git-flow/
+
+This was typed on the development branch, branch protections should prevent commits directly to the development branch
+
+First pass at proections did not work, so I had to add additional branch protections to prevent direct commits to main and development. They are now working and this comment is from feature branch add-comment-about-proections which was created with this command:
+
+git flow feature start add-comment-about-protections
+
+Since Git-Flow takes a local first approach the branch is created locally first. When you want to push code up to GitHub remote you will need to run a command like this to create the branch on the remote/origin and push the code up
+
+git push --set-upstream origin feature/add-comment-about-protections
+
+To finish the feature we are going to make one last commit to this branch, then create a Pull Request to merge changes from add-comment-about-protections to the development branch. Once the PR requirements/protections have been satisfied we will click Squash & Merge in the GitHub UI.
+
+The checkout the development branch locally, pull the most recent changes and then run:
+
+git flow feature finish add-comment-about-protections
+
+This will close the feature branch and get us ready to start a new feature branch.
+
+
+This was typed on the main branch, branch protections should prevent commits directly to the main branch
+
+When ready for a release use:
+
+git flow release start NameOfRelease/Branch
+
+Push it to GitHub git flow release publish NameOfRelease/Branch
+
+Publish Release git flow release finish NameOfRelease/Branch
+
+Resolve any merge conflicts
+
+Create PR for Main <- Release Branch
+
+Create PR for Development <- Release Branch
+
+Close Release in GitHub UI from main (production = main)

--- a/git-process.md
+++ b/git-process.md
@@ -1,0 +1,3 @@
+# Git Process
+
+This is a hotfix branch from main to intentionally throw development and main branch out of wack.


### PR DESCRIPTION
Can we force main on top of development. In practical use we'd be using this to force a release branch or development branch over main for deploys.